### PR TITLE
fix(io:server): Amend event signature to be identical for every event

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,33 @@ module.exports = ({ env }) => ({
       },
       "contentTypes": {
         "message": "*",
-        "chat":["create"]
+        "chat": ["create"]
       },
-      "events":[
+      "events": [
         {
           "name": "connection",
           "handler": ({ strapi }, socket) => {
             strapi.log.info(`[io] new connection with id ${socket.id}`);
+          },
+        },
+        {
+          "name": "hello",
+          "handler": ({ strapi, socket }) => {
+            strapi.log.info(`[io] hello ${socket.id}`);
+          },
+        },
+        {
+          "name": "hello-response",
+          "handler": ({ strapi, socket }, callback) => {
+            strapi.log.info(`[io] hello ${socket.id}`);
+            callback("Hello, there!")
+          },
+        },
+        {
+          "name": "hello-response-data",
+          "handler": ({ strapi, socket }, data, callback) => {
+            strapi.log.info(`[io] hello ${socket.id}, data ${data}`);
+            callback("Hello, there!")
           },
         },
       ]

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -27,12 +27,14 @@ module.exports = async ({ strapi }) => {
 			for (const event of normalizedSettings.events) {
 				// "connection" trigger should be executed immediately
 				if (event.name === 'connection') {
-					event.handler({ strapi }, socket);
+					event.handler({ strapi, io: strapi.$io, socket });
 					continue;
 				}
 
 				// register all other events to be triggered at a later time
-				socket.on(event.name, (...data) => event.handler({ strapi, io: strapi.$io }, ...data));
+				socket.on(event.name, (...data) =>
+					event.handler({ strapi, io: strapi.$io, socket }, ...data)
+				);
 			}
 		});
 	}


### PR DESCRIPTION
Hi,

Thanks for writing this - exactly when I needed it! 😄 

I've fixed an inconsistency between event types - IMO, they should be called identically in all cases, to make it easier.

The extra examples should help the new user get going quicker as well.