### PR TITLE
fix(getModelMeta): `publish` action should require update permission

### DIFF
--- a/server/utils/getModelMeta.js
+++ b/server/utils/getModelMeta.js
@@ -8,14 +8,11 @@ const getModelMeta = (model) => {
 
 	switch (action) {
 		case 'publish':
-			permission = permission.replace('publish', 'create');
+		case 'createOrUpdate':
+			permission = permission.replace(/publish|createOrUpdate/, 'update');
 			break;
 		case 'unpublish':
 			permission = permission.replace('unpublish', 'delete');
-			break;
-		// single types have create and update in a single action
-		case 'createOrUpdate':
-			permission = permission.replace('createOrUpdate', 'update');
 			break;
 		default:
 			break;


### PR DESCRIPTION
<!--- PR title should follow conventional commits (https://conventionalcommits.org) -->

### Description
This PR fixes the issue where publish evnets were not being emitted for single content types.

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation or readme)
- [X] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Relevant Issue(s)
#15 
