### PR TITLE
[bugfix] Fix handshake middleware rejecting confirmed users

### DIFF
--- a/server/middlewares/handshake.js
+++ b/server/middlewares/handshake.js
@@ -21,11 +21,11 @@ async function handshake(socket, next) {
 
 			const advancedSettings = await getAdvancedSettings();
 
-			if (advancedSettings.email_confirmation && !user.confirmed) {
+			if (advancedSettings.email_confirmation && !authUser.confirmed) {
 				throw Error('Invalid credentials');
 			}
 
-			if (user.blocked) {
+			if (authUser.blocked) {
 				throw Error('Invalid credentials');
 			}
 


### PR DESCRIPTION
<!--- PR title should follow conventional commits (https://conventionalcommits.org) -->

### Description

<!-- Describe your changes in detail -->
Handshake middleware was rejecting confirmed user connections since it checked the `user` object instead of `authUser`. `user` is only the decoded format of the jwt, thus does not have the `confirmed` or `blocked` fields. Both of these were returning `null`, causing confirmed user connections to be rejected

<!-- What changes have been made -->
Changed `user` to `authUser` so `confirmed` and `blocked` fields can be looked up

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Relevant Issue(s)

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
