### PR TITLE
fix(get rooms): fixed api token room logic

### DIFF
--- a/server/services/strategies.js
+++ b/server/services/strategies.js
@@ -180,9 +180,16 @@ module.exports = ({ strapi }) => {
 			return strapi.entityService.findMany('admin::api-token', {
 				fields: ['id', 'type', 'name'],
 				filters: {
-					expiresAt: {
-						$gte: new Date(),
-					},
+					$or: [
+						{
+							expiresAt: {
+								$gte: new Date(),
+							},
+						},
+						{
+							expiresAt: null,
+						},
+					],
 				},
 				populate: { permissions: true },
 			});


### PR DESCRIPTION
There was an issue where api tokens with an unlimited duration where not being returned in the get rooms function.  This is because a token with an unlimited duration has an expiresAt  of Null, and the greater than query

now the query searches for either valid token or ones that have an unlimited duration (aka null).

<!--- PR title should follow conventional commits (https://conventionalcommits.org) -->

### Description

<!-- Describe your changes in detail -->
<!-- What changes have been made -->

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation or readme)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Relevant Issue(s)

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
